### PR TITLE
Add error information for logger not declared

### DIFF
--- a/ANSIC.lby
+++ b/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<?AutomationStudio Version=4.5.5.113 SP?>
-<Library Version="0.23.3" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<?AutomationStudio FileVersion="4.9"?>
+<Library Version="0.23.4" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File>ErrorLib.html</File>
     <File>ErrorLib.md</File>

--- a/VersionHistory.txt
+++ b/VersionHistory.txt
@@ -1,3 +1,5 @@
+0.23.4 - Update error messages for logger not found
+
 0.23.3 - Update dependency versions
 
 0.23.2 - Update dependency versions

--- a/errcolInternalSetError.c
+++ b/errcolInternalSetError.c
@@ -113,6 +113,13 @@ switch( ErrorID ){
 	case 58300:
 	case 58301:
 	case 58302:	strncpy( t->OUT.STAT.ErrorString, "Logging error. Check loggers.", ERRCOL_STRLEN_ERRORSTRING ); break;
+		
+	/* ArEventLog Errors via LogThat */
+	// -1070586087 arEVENTLOG_ERR_LOGBOOK_NOT_FOUND to UINT is 10009
+	case 10009: 
+			strncpy( t->OUT.STAT.ErrorString, "Logging error. Logger not found: ", ERRCOL_STRLEN_ERRORSTRING ); 
+			strncat( t->OUT.STAT.ErrorString, t->IN.CFG.LoggerName, ERRCOL_STRLEN_ERRORSTRING - strlen(t->OUT.STAT.ErrorString) ); 
+			break;
 	
 	default:	strncpy( t->OUT.STAT.ErrorString, "Unknown error.", ERRCOL_STRLEN_ERRORSTRING ); break;
 	


### PR DESCRIPTION
Throws an error if logger is not found when logging errors.

This now a problem since LogThat no longer declares loggers if they are
not declared