### PR TITLE
Expand stringext dependency to support v0.15.x

### DIFF
--- a/src/Ar/ErrorLib/ANSIC.lby
+++ b/src/Ar/ErrorLib/ANSIC.lby
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<?AutomationStudio Version=4.5.5.113 SP?>
-<Library Version="0.23.3" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
+<?AutomationStudio FileVersion="4.9"?>
+<Library Version="0.23.4" SubType="ANSIC" xmlns="http://br-automation.co.at/AS/Library">
   <Files>
     <File Description="Exported data types">ErrorLib.typ</File>
     <File Description="Exported constants">ErrorLib.var</File>
@@ -27,7 +27,7 @@
     <Dependency ObjectName="sys_lib" />
     <Dependency ObjectName="HMITools" FromVersion="0.11.4" ToVersion="0.11.9" />
     <Dependency ObjectName="astime" />
-    <Dependency ObjectName="StringExt" FromVersion="0.14.1" ToVersion="0.14.9" />
+    <Dependency ObjectName="StringExt" FromVersion="0.14.1" ToVersion="0.15.9" />
     <Dependency ObjectName="LogThat" FromVersion="0.05.0" ToVersion="0.05.9" />
     <Dependency ObjectName="AsBrStr" />
   </Dependencies>

--- a/src/Ar/ErrorLib/CHANGELOG.md
+++ b/src/Ar/ErrorLib/CHANGELOG.md
@@ -1,3 +1,5 @@
+0.23.4 - Expand StringExt dependency
+
 0.23.3 - Update dependency versions
 
 0.23.2 - Update dependency versions


### PR DESCRIPTION
Expand StringExt dependency to support v0.15.x

StringExt v0.15.x is backwards-compatible with v0.14.x and should be allowed
