### PR TITLE
Add ErrorProg program-package publish workflow

### DIFF
--- a/.github/workflows/build-publish-errorprog.yml
+++ b/.github/workflows/build-publish-errorprog.yml
@@ -1,0 +1,123 @@
+name: Build and Publish ErrorProg
+
+# Program-package publish for ErrorProg (the Diagnostics starter program
+# inside this repo). Separate from the ErrorLib library publish because:
+#  - ErrorLib (library) and ErrorProg (program) follow independent release
+#    cadences. The program changes much less often.
+#  - Library is binary-published; program is source-only.
+#
+# Trigger: workflow_dispatch only. No tag-based auto-trigger to keep the
+# release independent from the library's `v*.*.*` tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. v1.0.0)'
+        required: true
+
+jobs:
+  build-publish:
+    runs-on: [AS6-runner]
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      PROJECT:     example/AsProject/AsProject.apj
+      PACKAGE_DIR: src/Ar/Diagnostics
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@loupeteam'
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          $ver = "${{ inputs.version }}" -replace '^v', ''
+          if (-not $ver) {
+            Write-Error "Could not determine version. Supply the version input (e.g. v1.0.0)."
+            exit 1
+          }
+          Write-Host "Publishing version: $ver"
+          "version=$ver" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_OUTPUT
+
+      - name: Verify program package
+        shell: pwsh
+        run: |
+          $pkgPath = Join-Path "${{ env.PACKAGE_DIR }}" "package.json"
+          if (-not (Test-Path $pkgPath)) {
+            Write-Error "package.json not found at $pkgPath"
+            exit 1
+          }
+          $pkg = Get-Content $pkgPath -Raw | ConvertFrom-Json
+          if ($pkg.lpm.type -ne 'program') {
+            Write-Error "Expected lpm.type == 'program' in $pkgPath, got '$($pkg.lpm.type)'. This workflow is for program packages only."
+            exit 1
+          }
+          Write-Host "Confirmed program package: $($pkg.name)"
+
+      - name: Find AS6 build executable
+        uses: loupeteam/br-actions/find-as6-build@v1
+        id: find-as
+
+      - name: Build Intel
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path: ${{ steps.find-as.outputs.exe-path }}
+          project:  ${{ env.PROJECT }}
+          config:   Intel
+
+      - name: Build ARM
+        uses: loupeteam/br-actions/build-as-project@v1
+        with:
+          exe-path: ${{ steps.find-as.outputs.exe-path }}
+          project:  ${{ env.PROJECT }}
+          config:   ARM
+
+      - name: Set package version
+        shell: pwsh
+        run: |
+          Push-Location "${{ env.PACKAGE_DIR }}"
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          Pop-Location
+
+      - name: Copy README into package
+        shell: pwsh
+        run: |
+          if (Test-Path README.md) {
+            Copy-Item -Path README.md -Destination "${{ env.PACKAGE_DIR }}/README.md" -Force
+          }
+
+      - name: Publish to GitHub Packages
+        shell: pwsh
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Push-Location "${{ env.PACKAGE_DIR }}"
+          npm publish
+          Pop-Location
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: errorprog-${{ steps.version.outputs.version }}
+          path: ${{ env.PACKAGE_DIR }}/
+          if-no-files-found: error
+
+      - name: Upload build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BuildDiagnostics
+          path: example/AsProject/Temp/BuildDiagnostics.log
+          if-no-files-found: ignore

--- a/src/Ar/Diagnostics/CHANGELOG.md
+++ b/src/Ar/Diagnostics/CHANGELOG.md
@@ -1,2 +1,3 @@
 # Change log
+- 1.0.0 - AS6 migration. Bump deps to AS6-compatible versions (`@loupeteam/hmitools` and `@loupeteam/errorlib` >=1.0.0). Add `build-publish-errorprog.yml` workflow for manual program-package publishes.
 - 0.01.0 - First version

--- a/src/Ar/Diagnostics/package.json
+++ b/src/Ar/Diagnostics/package.json
@@ -1,16 +1,20 @@
 {
   "name": "@loupeteam/errorprog",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "This is a program package that will add the error program to your AS project",
+  "homepage": "https://loupeteam.github.io/LoupeDocs/programs/errorprog.html",
   "author": "Loupe",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/loupeteam/ErrorLib.git"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "dependencies": {
-    "@loupeteam/hmitools": "^0.11.4",
-    "@loupeteam/errorlib": "^0.23.3"
+    "@loupeteam/hmitools": ">=1.0.0",
+    "@loupeteam/errorlib": ">=1.0.0"
   },
   "lpm": {
     "type": "program",


### PR DESCRIPTION
## What
Adds a separate publish workflow for the ErrorProg program package that lives in this repo at `src/Ar/Diagnostics/`.

## Background
This repo ships two packages:
- `@loupeteam/errorlib` (binary library, just published as v1.0.0)
- `@loupeteam/errorprog` (program package — never had a publish workflow)

Programs in our AS6 model are source-only publishes (no binary export). They also tend to change much less often than the library, so the program-publish is decoupled from the library's `v*.*.*` tag namespace.

## Changes
- New `.github/workflows/build-publish-errorprog.yml` — manual `workflow_dispatch` only, takes a version input. Builds the example project for sanity, then `npm publish` from `src/Ar/Diagnostics/`.
- Bump `src/Ar/Diagnostics/package.json`:
  - version 0.1.0 → 1.0.0
  - hmitools dep `^0.11.4` → `>=1.0.0`
  - errorlib dep `^0.23.3` → `>=1.0.0`
  - Add `publishConfig` (npm.pkg.github.com) and `homepage`

## After merge
Trigger the workflow with version input `v1.0.0` to publish `@loupeteam/errorprog@1.0.0`. This unblocks FirstInitProg PR #4.